### PR TITLE
Bug fixes (static/const variables)

### DIFF
--- a/src/fmm-action.c
+++ b/src/fmm-action.c
@@ -157,9 +157,9 @@ void disaggregate(fmm_box_t *tbox) {
     for (int j = 0; j < 8; j++) {
       fmm_box_t *cbox = sbox->child[j]; 
       if (cbox != NULL) {
-        if (fabs(tbox->idx - cbox->idx) <= 1 &&
-            fabs(tbox->idy - cbox->idy) <= 1 &&
-            fabs(tbox->idz - cbox->idz) <= 1) 
+        if (abs(tbox->idx - cbox->idx) <= 1 &&
+            abs(tbox->idy - cbox->idy) <= 1 &&
+            abs(tbox->idz - cbox->idz) <= 1) 
           list5[nlist5++] = cbox;
       }
     }

--- a/src/fmm-action.c
+++ b/src/fmm-action.c
@@ -570,10 +570,10 @@ void source_to_multipole(fmm_box_t *sbox) {
 }
 
 void multipole_to_multipole(fmm_box_t *sbox) {
-  const double complex var[5] =
+  static const double complex var[5] =
     {1,-1 + _Complex_I, 1 + _Complex_I, 1 - _Complex_I, -1 - _Complex_I};
-  const double arg = sqrt(2)/2.0;
-  const int iflu[8] = {3, 4, 2, 1, 3, 4, 2, 1};
+  static const double arg = 1.4142135623730950488016887242097 / 2.0; /* sqrt(2)/2 */
+  static const int iflu[8] = {3, 4, 2, 1, 3, 4, 2, 1};
 
   int pterms = fmm_param->pterms;
   int pgsz   = fmm_param->pgsz;
@@ -2194,10 +2194,10 @@ void exponential_to_local_p2(int iexpu, const double complex *mexpu,
 }
 
 void local_to_local(fmm_box_t *tbox) {
-  const double complex var[5] =
+  static const double complex var[5] =
     {1, 1 - _Complex_I, -1 - _Complex_I, -1 + _Complex_I, 1 + _Complex_I};
-  const double arg = sqrt(2) / 2.0;
-  const int ifld[8] = {1, 2, 4, 3, 1, 2, 4, 3};
+  static const double arg = 1.4142135623730950488016887242097 / 2.0; /* sqrt(2)/2 */
+  static const int ifld[8] = {1, 2, 4, 3, 1, 2, 4, 3};
 
   int pterms = fmm_param->pterms;
   int pgsz   = fmm_param->pgsz;
@@ -2752,10 +2752,10 @@ void source_to_multipole(fmm_box_t *sbox) {
 }
 
 void multipole_to_multipole(fmm_box_t *sbox) {
-  const double complex var[5] = 
+  static const double complex var[5] =
     {0, -1 + _Complex_I, 1 + _Complex_I, 1 - _Complex_I, -1 - _Complex_I};
-  const double arg = sqrt(2.0) / 2.0;
-  const int yifl[8] = {3, 4, 2, 1, 3, 4, 2, 1}; 
+  static const double arg = 1.4142135623730950488016887242097 / 2.0; /* sqrt(2)/2 */
+  static const int yifl[8] = {3, 4, 2, 1, 3, 4, 2, 1};
 
   int level  = sbox->level; 
   int pterms = fmm_param->pterms;
@@ -4330,10 +4330,10 @@ void exponential_to_local_p2(int iexpu, const double complex *mexpu,
 }
 
 void local_to_local(fmm_box_t *tbox) {
-  const double complex var[5] = 
+  static const double complex var[5] =
     {0, 1 - _Complex_I, -1 - _Complex_I, -1 + _Complex_I, 1 + _Complex_I};
-  const double arg = sqrt(2.0) / 2.0;
-  const int yifl[8] = {3, 4, 2, 1, 3, 4, 2, 1}; 
+  static const double arg = 1.4142135623730950488016887242097 / 2.0; /* sqrt(2)/2 */
+  static const int yifl[8] = {3, 4, 2, 1, 3, 4, 2, 1};
 
   int level  = tbox->level; 
   int pterms = fmm_param->pterms;

--- a/src/fmm-param.c
+++ b/src/fmm-param.c
@@ -884,7 +884,7 @@ void yhfstrtn(int p, double theta, const double *sqc, double *d, int pgsz) {
   for (int ij = 0; ij <= p; ij++) {
     for (int im = 0; im <= ij; im++) {
       for (int imp = -ij; imp <= ij; imp++) {
-        int impabs = fabs(imp);
+        int impabs = abs(imp);
         d[ij + im * (p + 1) + (imp + p) * pgsz] *=
           sqrt(fac[ij + im] / fac[ij + impabs] * 
                fac[ij - impabs] / fac[ij - im]);
@@ -1344,7 +1344,7 @@ void kn(double scal, double x, int nb, double *by, int *ncalc) {
     u2 = scal * scal;
     n = nb;
     for (i = 2; i <= n; ++i) {
-      if ((d__1 = by[i - 1], abs(d__1)) * u1 >= 
+      if ((d__1 = by[i - 1], fabs(d__1)) * u1 >= 
           xinf / (double) ((i << 1) - 1)) {
         break;  // goto L450;
       }

--- a/src/fmm-param.c
+++ b/src/fmm-param.c
@@ -1179,9 +1179,9 @@ void kn(double scal, double x, int nb, double *by, int *ncalc) {
   
   /* Initialized data */
   
-  static double xmin = 4.46e-308;
-  static double xinf = 1.79e308;
-  static double xlarge = 1e8;
+  static const double xmin = 4.46e-308;
+  static const double xinf = 1.79e308;
+  static const double xlarge = 1e8;
   
   /* System generated locals */
   int n;
@@ -1191,8 +1191,10 @@ void kn(double scal, double x, int nb, double *by, int *ncalc) {
   double atan(double), exp(double);
   
   /* Local variables */
-  static int i;
-  static double p, u1, u2, ex, zero, halfpi;
+  int i;
+  double p, u1, u2, ex;
+  static const double zero = 0.0;
+  static const double halfpi = 1.57079632679; // atan(1.) * 2.;
 
   /* ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccd */
   
@@ -1328,7 +1330,6 @@ void kn(double scal, double x, int nb, double *by, int *ncalc) {
   /*  machine-dependent constants */
   /* ---------------------------------------------------------------------- */
   /* ---------------------------------------------------------------------- */
-  halfpi = 1.57079632679; // atan(1.) * 2.;
   ex = x;
   if (nb >= 0 && x >= xmin && ex < xlarge) {
     

--- a/test/fmm-test.c
+++ b/test/fmm-test.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <stdbool.h>
+#include <assert.h>
 #include "fmm.h"
 
 static void usage(FILE *stream) {
@@ -31,7 +32,7 @@ static void usage(FILE *stream) {
 	  "\t-d, distribution of the particles\n"
 	  "\t    type-1 data is uniformly distributed inside a box\n"
 	  "\t    type-2 data is uniformly distributed over a sphere\n"
-    "\t-b, parameter beta (>=0) for Yukawa kernel exp(-bata * r) / r\n"
+	  "\t-b, parameter beta (>=0) for Yukawa kernel exp(-beta * r) / r\n"
 	  "\t-s, maximum number of points allowed per leaf box\n");
 }
 


### PR DESCRIPTION
Fixes:
- certain determinacy races which could lead to NaN output or segfaults;
- stack overflow warnings by AddressSanitizer.

Both issues arose due to seemingly unintended use (or lack) of `static`/`const` qualifiers.

Also fixes some other minor issues.

See the commits for more info.