### PR TITLE
OpenCilk support and Meson build script

### DIFF
--- a/example/meson.build
+++ b/example/meson.build
@@ -1,0 +1,1 @@
+src_recfmm_example = files(['example.c'])

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,8 @@
+recfmm_hdrs = files(['cilk.h',
+                     'fmm-action.h',
+                     'fmm-dag.h',
+                     'fmm-param.h',
+                     'fmm-types.h',
+                     'fmm.h'])
+
+recfmm_include_dir = include_directories('.')

--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,25 @@ endif
 
 recfmm_dep = [tbbmalloc_dep, m_dep]
 
+# ========== instrumentation tools
+
+if get_option('cilktool') == 'cilksan' # ----- Cilksan
+  if not (use_opencilk and have_cilk_headers)
+    warning('Cilksan instrumentation specified but not using OpenCilk compiler;' +
+            ' skipping...')
+  else
+    add_project_arguments(['-fsanitize=cilk','-fno-stripmine',
+                           '-fno-vectorize','-fno-unroll-loops'], language : 'c')
+    add_project_link_arguments(['-fsanitize=cilk'], language : 'c')
+    # FIXME [2021-01-25] Meson does not support static-library-only arguments to
+    # build targets defined via `library()`.  See also:
+    # https://github.com/mesonbuild/meson/issues/3304
+    if get_option('default_library') != 'static'
+      add_project_link_arguments(['-shared-libasan'], language : 'c')
+    endif
+  endif
+endif
+
 # ========== build targets
 
 # headers

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,169 @@
+project('recFMM', ['c', 'fortran'],
+        version : '0.1.1',
+        license : 'GPL-3.0-or-later',
+        meson_version : '>=0.49.0',
+        default_options : ['c_std=gnu99',
+                           'buildtype=release',
+                           'default_library=both',
+                           'prefix=' + meson.current_source_dir()])
+
+vso = '0'
+
+# ========== compiler options and dependencies
+
+cc = meson.get_compiler('c')
+fc = meson.get_compiler('fortran')
+
+cc_is_icc = cc.get_id().contains('intel')
+use_opencilk = not cc_is_icc and cc.has_argument('-fopencilk')
+use_cilkplus = not use_opencilk \
+               and (cc_is_icc or cc.has_argument('-fcilkplus'))
+
+# HACK GNU gcc 8.x and 9.x still accept `-fcilkplus` even though they do not
+# actually support Cilk...
+cc_is_gcc_with_cilk = cc.get_id() == 'gcc' and \
+                      cc.version().version_compare('>=5.0.0') and \
+                      cc.version().version_compare('<8.1.0')
+if use_cilkplus and cc.get_id() == 'gcc' and not cc_is_gcc_with_cilk
+  warning('The specified GCC version does not support Cilk' +
+          ' (even though -fcilkplus does not trigger an error).')
+  use_cilkplus = false
+endif
+
+if use_opencilk or use_cilkplus
+  have_cilk_headers = cc.has_header('cilk/cilk.h') and \
+                      cc.has_header('cilk/cilk_api.h') and \
+                      cc.has_header('cilk/reducer_min.h') and \
+                      cc.has_header('cilk/reducer_max.h')
+  if not have_cilk_headers
+    warning('Required Cilk headers not found. Switching to sequential build.')
+  endif
+endif
+
+if cc_is_icc
+  add_project_arguments(['-Dicc'], language : 'c') # enables SIMD reduction
+endif
+
+m_dep = cc.find_library('m', required : false)
+
+# ========== parallel vs sequential implementation
+
+flag_parallel = (use_opencilk or use_cilkplus) and have_cilk_headers
+
+if flag_parallel                # ----- parallel build
+
+  # Cilk flags
+  if use_opencilk
+    cilk_cflags  = ['-fopencilk']
+    cilk_ldflags = ['-fopencilk']
+  elif use_cilkplus and not cc_is_icc
+    cilk_cflags  = ['-fcilkplus']
+    cilk_ldflags = ['-lcilkrts']
+  else
+    cilk_cflags  = []
+    cilk_ldflags = []
+  endif
+  add_project_arguments([cilk_cflags, '-DUSING_CILK'], language : 'c')
+  add_project_link_arguments([cilk_ldflags], language : 'c')
+
+  # Intel TBB scalable allocator
+  tbb_dir = get_option('tbb_dir')
+  if tbb_dir == ''
+    tbb_dir = []
+  endif
+  tbbmalloc_dep = dependency('tbbmalloc', required : false)
+  if not tbbmalloc_dep.found()
+    tbbmalloc_dep = cc.find_library('tbbmalloc', required : true,
+                                    dirs : tbb_dir)
+  endif
+
+else                            # ----- sequential build
+
+  warning('Could not verify Cilk support with the specified compiler.' +
+          ' Cilk keywords elided.')
+
+  tbbmalloc_dep = dependency('', required : false)
+
+endif
+
+recfmm_dep = [tbbmalloc_dep, m_dep]
+
+# ========== build targets
+
+# headers
+subdir('include')
+install_headers(recfmm_hdrs, install_dir : 'include')
+
+# source files
+subdir('src')
+subdir('test')
+subdir('example')
+
+def_lap = ['-DLAPLACE']
+def_yuk = ['-DYUKAWA']
+
+# recFMM libraries: Laplace & Yukawa
+lib_lap = library('adap_laplace', [src_recfmm_laplace],
+                  c_args : def_lap,
+                  dependencies : recfmm_dep,
+                  include_directories : [recfmm_include_dir],
+                  install : true, install_dir : 'lib',
+                  soversion : vso)
+lib_yuk = library('adap_yukawa', [src_recfmm_yukawa],
+                  c_args : def_yuk,
+                  dependencies : recfmm_dep,
+                  include_directories : [recfmm_include_dir],
+                  install : true, install_dir : 'lib',
+                  soversion : vso)
+
+# test executables
+exe_test_lap = executable('recfmm-test-laplace', [src_recfmm_test],
+                          c_args : def_lap, link_with : lib_lap,
+                          dependencies : recfmm_dep,
+                          include_directories : [recfmm_include_dir],
+                          install_rpath : get_option('prefix') / 'lib',
+                          install : true, install_dir : 'test')
+exe_test_yuk = executable('recfmm-test-yukawa', [src_recfmm_test],
+                          c_args : def_yuk, link_with : lib_yuk,
+                          dependencies : recfmm_dep,
+                          include_directories : [recfmm_include_dir],
+                          install_rpath : get_option('prefix') / 'lib',
+                          install : true, install_dir : 'test')
+
+# example executable
+exe_example_lap = executable('recfmm-example', [src_recfmm_example],
+                             c_args : def_lap, link_with : lib_lap,
+                             dependencies : recfmm_dep,
+                             include_directories : [recfmm_include_dir],
+                             install_rpath : get_option('prefix') / 'lib',
+                             install : true, install_dir : 'example')
+
+# ========== tests
+
+test_verifier = find_program('test/verify_test_pass.sh')
+
+test('Laplace [box, acc=3]', test_verifier,
+     args : [exe_test_lap, '-d1', '-a3'],
+     suite : ['laplace', 'box', 'low_acc'])
+test('Laplace [sphere, acc=3]', test_verifier,
+     args : [exe_test_lap, '-d2', '-a3'],
+     suite : ['laplace', 'sphere', 'low_acc'])
+test('Laplace [box, acc=6]', test_verifier,
+     args : [exe_test_lap, '-d1', '-a6'],
+     suite : ['laplace', 'box', 'high_acc'])
+test('Laplace [sphere, acc=6]', test_verifier,
+     args : [exe_test_lap, '-d2', '-a6'],
+     suite : ['laplace', 'sphere', 'high_acc'])
+
+test('Yukawa [box, acc=3]', test_verifier,
+     args : [exe_test_yuk, '-d1', '-a3'],
+     suite : ['yukawa', 'box', 'low_acc'])
+test('Yukawa [sphere, acc=3]', test_verifier,
+     args : [exe_test_yuk, '-d2', '-a3'],
+     suite : ['yukawa', 'sphere', 'low_acc'])
+test('Yukawa [box, acc=6]', test_verifier,
+     args : [exe_test_yuk, '-d1', '-a6'],
+     suite : ['yukawa', 'box', 'high_acc'])
+test('Yukawa [sphere, acc=6]', test_verifier,
+     args : [exe_test_yuk, '-d2', '-a6'],
+     suite : ['yukawa', 'sphere', 'high_acc'])

--- a/meson_build_instructions.md
+++ b/meson_build_instructions.md
@@ -1,0 +1,78 @@
+## RecFMM build instructions with Meson
+
+### Requirements
+
+#### Build system
+
+The updated recFMM port can be built using the [Meson][meson-home] build system
+with the [Ninja][ninja-home] backend. These can be installed via `pip`:
+
+    pip install meson
+    pip install ninja
+
+For more information on installing Meson and Ninja, refer to their respective
+websites.
+
+[meson-home]: https://mesonbuild.com/
+[ninja-home]: https://ninja-org.build/
+
+#### Compiler with Cilk support
+
+The recFMM library supports shared-memory multi-threaded computations using the
+Cilk C-language extensions and reducer hyperobjects.  To do that, you must use a
+Cilk-supported C compiler.  RecFMM has been tested with the following C
+compilers:
+
+- [OpenCilk][opencilk-home] 1.0 (based on `clang` 10.0.1)
+- GNU `gcc` 7.5.0
+- Intel `icc` 19.1.2.254
+
+We recommend using the newly released [OpenCilk][opencilk-home] compiler, as
+Cilk support via the legacy Cilk Plus platform has been removed or deprecated in
+other compilers.
+
+A Fortran compiler is also required.  RecFMM has been tested with the
+following Fortran compilers:
+
+- GNU `gfortran` 7.5.0, 9.3.0
+- Intel `ifort` 19.1.2.254
+
+#### Memory allocation
+
+Efficient memory allocation is supported via the Intel TBB scalable allocator
+library, `tbbmalloc`, if that is available in your system.
+
+### Building recFMM
+
+#### Configuration
+
+    CC=<c-compiler> FC=<fortran-compiler> meson path/to/build/directory
+
+By default, Meson looks for dependencies using `pkg-config`.  To specify a
+custom TBB installation directory, use
+
+    CC=<c-compiler> FC=<fortran-compiler> meson -Dtbb_dir=path/to/tbb/directory path/to/build/directory
+
+For additional configuration options, refer to the [Meson built-in
+options][meson-builtin-options] web page.
+
+[meson-builtin-options]: https://mesonbuild.com/Builtin-options.html
+
+#### Compilation
+
+    meson compile -C path/to/build/directory
+
+#### Testing
+
+    meson test -C path/to/build/directory
+
+### Contributors
+
+_Algorithm and library development:_
+- Bo Zhang
+- Jingfang Huang
+- Nikos P. Pitsianis
+- Xiaobai Sun
+
+_Meson build config, OpenCilk support, bug fixes:_
+- Alexandros-Stavros Iliopoulos

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,9 @@
+option('cilktool',
+       type : 'combo',
+       choices : ['', 'none', 'cilksan', 'cilkscale'],
+       value : '',
+       description : 'OpenCilk instrumentation tool')
+
 option('tbb_dir',
        type : 'string',
        value : '',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('tbb_dir',
+       type : 'string',
+       value : '',
+       description : 'Absolute path to Intel TBB installation directory')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,8 @@
+c_sources = files(['fmm-action.c',
+                   'fmm-dag.c',
+                   'fmm-param.c'])
+f_sources = files(['ribesl.f',
+                   'dgamma.f'])
+
+src_recfmm_laplace = c_sources
+src_recfmm_yukawa  = c_sources + f_sources

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,1 @@
+src_recfmm_test = files(['fmm-test.c'])

--- a/test/verify_test_pass.sh
+++ b/test/verify_test_pass.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+EXEC=$1; shift
+
+$EXEC "$@" | grep "\*\{7\} pass \*\{7\}"


### PR DESCRIPTION
This adds a fairly comprehensive [Meson](https://mesonbuild.com/) build config script and a short installation-instructions document.  These are intended to replace the existing `Makefile`s, although the latter are not deleted in the PR.

The Meson build script adds support for building with the new [OpenCilk](http://opencilk.org) compiler.  (Note that Intel Cilk Plus is deprecated.)

Options are also provided to enable instrumentation with Cilksan, which checks for determinacy races.  This feature is self-contained in 6d3e9a137a5a77100560df9974df46d3a9427a42 to make it easy to drop if unwanted.